### PR TITLE
Add WIC image definitions and set as default

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -55,6 +55,7 @@ BB_DISKMON_DIRS ??= "\
 #IMAGE_FSTYPES = "tar.gz wic ubifs emmc"
 
 # Select a preconfigured A/B system setup for SD/eMMC images.
+WKS_FILES_mx8mm = "imx8mm-esec-iotdm-sdimage.wks"
 
 # Turn on debugging options of the kernel
 DEBUG_BUILD_pn-linux-mainline = "1"

--- a/scripts/lib/wic/canned-wks/esec-iotdm-sdimage.wks.in
+++ b/scripts/lib/wic/canned-wks/esec-iotdm-sdimage.wks.in
@@ -1,0 +1,7 @@
+part --source bootimg-partition --fstype vfat --label boot0 --ondisk mmc --active --fixed-size 128 --align 4096
+part --source bootimg-partition --fstype vfat --label boot1 --ondisk mmc --active --fixed-size 128
+part --fstype ext4 --label config --ondisk mmc --fixed-size 64
+part / --source rootfs --fstype ext4 --label root0 --ondisk mmc --use-uuid --fixed-size 1024
+part / --source rootfs --fstype ext4 --label root1 --ondisk mmc --use-uuid --fixed-size 1024
+part /mnt/app --fstype ext4 --label app0 --ondisk mmc --fixed-size 768
+part /mnt/app --fstype ext4 --label app1 --ondisk mmc --fixed-size 768

--- a/scripts/lib/wic/canned-wks/imx8mm-esec-iotdm-sdimage.wks
+++ b/scripts/lib/wic/canned-wks/imx8mm-esec-iotdm-sdimage.wks
@@ -1,0 +1,3 @@
+part U-BOOT --source rawcopy --sourceparams="file=imx-boot" --ondisk mmc --no-table --align 33
+
+include esec-iotdm-sdimage.wks.in


### PR DESCRIPTION
Add WIC image definitions and set these as the new default in the local.conf. We want all SD images to contain the full partition layout with redundant boot, rootfs and app partitions. For now, this adds image definitions for i.MX8MM based boards.

App partitions may not be fully utilized at the moment.