### PR TITLE
Change partitions and default boot target for A/B system

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/0001-include-configs-Change-A-B-system-partitions.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0001-include-configs-Change-A-B-system-partitions.patch
@@ -1,0 +1,47 @@
+From 90451f240d83cfb2797f22697e329a31cda40079 Mon Sep 17 00:00:00 2001
+From: Martin Schwan <m.schwan@phytec.de>
+Date: Mon, 15 Feb 2021 14:53:08 +0100
+Subject: [PATCH 1/2] include: configs: Change A/B system partitions
+
+Change the A/B system layout to the following scheme and adjust the
+partition numbering accordingly:
+
+    partition name  partition number
+    --------------  ----------------
+    boot0           1
+    boot1           2
+    config          3
+    extended        4
+        root0       5
+        root1       6
+        app0        7
+        app1        8
+
+Signed-off-by: Martin Schwan <m.schwan@phytec.de>
+---
+ include/configs/phycore_rauc_env.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/include/configs/phycore_rauc_env.h b/include/configs/phycore_rauc_env.h
+index 48b15556ef..8e6fee95ac 100644
+--- a/include/configs/phycore_rauc_env.h
++++ b/include/configs/phycore_rauc_env.h
+@@ -35,11 +35,11 @@
+ #define PHYCORE_RAUC_ENV_BOOTLOGIC \
+ 	"raucslot=system0\0" \
+ 	"raucbootpart=1\0" \
+-	"raucrootpart=2\0" \
++	"raucrootpart=5\0" \
+ 	"raucbootpart0=1\0" \
+-	"raucrootpart0=2\0" \
+-	"raucbootpart1=3\0" \
+-	"raucrootpart1=4\0" \
++	"raucrootpart0=5\0" \
++	"raucbootpart1=2\0" \
++	"raucrootpart1=6\0" \
+ 	"raucargs=setenv bootargs console=${console} " \
+ 		"root=/dev/mmcblk${raucdev}p${raucrootpart} " \
+ 		"rauc.slot=${raucslot} rootwait rw\0" \
+-- 
+2.30.1
+

--- a/recipes-bsp/u-boot/u-boot-imx/0002-include-configs-Enable-booting-A-B-system-by-default.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0002-include-configs-Enable-booting-A-B-system-by-default.patch
@@ -1,0 +1,27 @@
+From 62988c54b7773eb0705805c00427510ce011152f Mon Sep 17 00:00:00 2001
+From: Martin Schwan <m.schwan@phytec.de>
+Date: Mon, 15 Feb 2021 15:22:16 +0100
+Subject: [PATCH 2/2] include: configs: Enable booting A/B system by default
+ for i.MX8M Mini
+
+Signed-off-by: Martin Schwan <m.schwan@phytec.de>
+---
+ include/configs/phycore_imx8mm.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/phycore_imx8mm.h b/include/configs/phycore_imx8mm.h
+index 02793fc554..469df45e15 100644
+--- a/include/configs/phycore_imx8mm.h
++++ b/include/configs/phycore_imx8mm.h
+@@ -77,7 +77,7 @@
+ 		"else " \
+ 			"echo WARN: Cannot load the DT; " \
+ 		"fi;\0" \
+-	"doraucboot=0\0" \
++	"doraucboot=1\0" \
+ 	"raucdev=2\0" \
+ 	PHYCORE_RAUC_ENV_BOOTLOGIC
+ 
+-- 
+2.30.1
+

--- a/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://0001-include-configs-Change-A-B-system-partitions.patch \
+    file://0002-include-configs-Enable-booting-A-B-system-by-default.patch \
+"

--- a/recipes-core/rauc/rauc/mx8mm/system_emmc.conf
+++ b/recipes-core/rauc/rauc/mx8mm/system_emmc.conf
@@ -1,0 +1,37 @@
+[system]
+compatible=@MACHINE@
+bootloader=uboot
+mountprefix=/mnt/rauc
+
+[handlers]
+pre-install=/usr/bin/rauc_downgrade_barrier.sh
+
+[keyring]
+path=ca.cert.pem
+
+# Bootloader
+[slot.bootloader.0]
+device=/dev/mmcblk2
+type=boot-emmc
+
+# System A
+[slot.rootfs.0]
+device=/dev/mmcblk2p5
+type=ext4
+bootname=system0
+
+[slot.boot.0]
+device=/dev/mmcblk2p1
+type=vfat
+parent=rootfs.0
+
+# System B
+[slot.rootfs.1]
+device=/dev/mmcblk2p6
+type=ext4
+bootname=system1
+
+[slot.boot.1]
+device=/dev/mmcblk2p2
+type=vfat
+parent=rootfs.1

--- a/recipes-core/rauc/rauc_%.bbappend
+++ b/recipes-core/rauc/rauc_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'emmc', 'file://system_emmc.conf', 'file://system_nand.conf', d)} \
+"


### PR DESCRIPTION
Change the partitions for the specified A/B system. Enable booting the A/B system by default. Add a fitting RAUC system.conf to utilize the new partitioning configuration.