### PR TITLE
Add recipe for awsclient binary

### DIFF
--- a/recipes-connectivity/awsclient/awsclient/awsclient.service
+++ b/recipes-connectivity/awsclient/awsclient/awsclient.service
@@ -6,7 +6,7 @@ After=network.target
 Type=oneshot
 User=root
 ExecStart=/usr/bin/awsclient
-WorkingDirectory=/root/
+WorkingDirectory=/mnt/config/aws/
 TimeoutStartSec=15m
 
 [Install]

--- a/recipes-connectivity/awsclient/awsclient/awsclient.service
+++ b/recipes-connectivity/awsclient/awsclient/awsclient.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OSB AWS Client
+After=network.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/bin/awsclient
+WorkingDirectory=/root/
+TimeoutStartSec=15m
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-connectivity/awsclient/awsclient/awsclient.timer
+++ b/recipes-connectivity/awsclient/awsclient/awsclient.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer for executing OSB AWS Client periodically
+
+[Timer]
+OnActiveSec=1m
+OnUnitActiveSec=30m
+
+[Install]
+WantedBy=basic.target

--- a/recipes-connectivity/awsclient/awsclient_1.3.1.bb
+++ b/recipes-connectivity/awsclient/awsclient_1.3.1.bb
@@ -1,0 +1,35 @@
+SUMMARY = "The AWS IoT client establishes a connection to AWS IoT, executes jobs and sends status information."
+
+LICENSE = "CLOSED"
+
+SRC_URI = "\
+    https://github.com/osb-cc-esec/meta-esec-awsclient/releases/download/v${PV}/awsclient_${PV}_aarch64 \
+    file://awsclient.service \
+    file://awsclient.timer \
+"
+
+SRC_URI[md5sum] = "83b5a82ab97649fa065a3b99f5a5d8ce"
+SRC_URI[sha256sum] = "6c5183522734539c58841703ef856096a205e54f315330d3d511a6d03f1b0840"
+
+DEPENDS = "curl glib-2.0 json-glib openssl"
+
+inherit systemd
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE_${PN} = "awsclient.timer"
+
+do_install () {
+    install -d ${D}${bindir}/
+    install -m 0755 ${WORKDIR}/awsclient_${PV}_aarch64 ${D}${bindir}/awsclient
+
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/awsclient.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/awsclient.timer ${D}${systemd_unitdir}/system/
+}
+
+FILES_${PN} += " \
+    ${systemd_unitdir}/system/awsclient.service \
+    ${systemd_unitdir}/system/awsclient.timer \
+"
+
+INSANE_SKIP_${PN}_append = "already-stripped"

--- a/recipes-connectivity/awsclient/awsclient_1.3.1.bb
+++ b/recipes-connectivity/awsclient/awsclient_1.3.1.bb
@@ -3,24 +3,23 @@ SUMMARY = "The AWS IoT client establishes a connection to AWS IoT, executes jobs
 LICENSE = "CLOSED"
 
 SRC_URI = "\
-    https://github.com/osb-cc-esec/meta-esec-awsclient/releases/download/v${PV}/awsclient_${PV}_aarch64 \
+    https://github.com/osb-cc-esec/meta-esec-awsclient/releases/download/v${PV}/awsclient_${PV}_${TARGET_ARCH} \
     file://awsclient.service \
     file://awsclient.timer \
 "
 
-SRC_URI[md5sum] = "83b5a82ab97649fa065a3b99f5a5d8ce"
-SRC_URI[sha256sum] = "6c5183522734539c58841703ef856096a205e54f315330d3d511a6d03f1b0840"
+SRC_URI[md5sum] = "95b24fb7a64746efac2f2ce57ca2215a"
+SRC_URI[sha256sum] = "e5542f3acbadefe71d9b2fd5b9af9cf1d5acfa436afb9316998d5dbb2cedaae3"
 
 DEPENDS = "curl glib-2.0 json-glib openssl"
 
 inherit systemd
 
-SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE_${PN} = "awsclient.timer"
 
 do_install () {
     install -d ${D}${bindir}/
-    install -m 0755 ${WORKDIR}/awsclient_${PV}_aarch64 ${D}${bindir}/awsclient
+    install -m 0755 ${WORKDIR}/awsclient_${PV}_${TARGET_ARCH} ${D}${bindir}/awsclient
 
     install -d ${D}${systemd_unitdir}/system/
     install -m 0644 ${WORKDIR}/awsclient.service ${D}${systemd_unitdir}/system/

--- a/recipes-images/images/phytec-test-image.bb
+++ b/recipes-images/images/phytec-test-image.bb
@@ -25,6 +25,7 @@ IMAGE_INSTALL = " \
     tzdata \
     ntp \
     curl \
+    awsclient \
 "
 
 IMAGE_INSTALL_append_mx6 = " firmwared"


### PR DESCRIPTION
Add recipe for awsclient binary and include it in the image.

The binary is hosted in a public repository with the recipe that builds the awsclient binary from source.
[https://github.com/osb-cc-esec/meta-esec-awsclient/releases](https://github.com/osb-cc-esec/meta-esec-awsclient/releases)

For now the "binary" is only a simple shell script.