### PR TITLE
Add A/B slots for applications

### DIFF
--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -1,0 +1,8 @@
+/dev/root       /              auto    defaults              1  1
+proc            /proc          proc    defaults              0  0
+devpts          /dev/pts       devpts  mode=0620,gid=5       0  0
+tmpfs           /run           tmpfs   mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs           /var/volatile  tmpfs   defaults              0  0
+
+/dev/mmcblk2p3  /mnt/config    auto    defaults              0  0
+/dev/appfs      /mnt/app       auto    defaults              0  0

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += " \
+    file://fstab \
+"

--- a/recipes-core/rauc/rauc/appfs.rules
+++ b/recipes-core/rauc/rauc/appfs.rules
@@ -1,0 +1,1 @@
+KERNEL=="mmcblk2p[78]", PROGRAM="@LIBDIR@/@PN@/is-parent-active %k", RESULT=="1", SYMLINK+="appfs"

--- a/recipes-core/rauc/rauc/is-parent-active
+++ b/recipes-core/rauc/rauc/is-parent-active
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+RAUC_SYSTEM_CONF="/etc/rauc/system.conf"
+PARSED_CONF=$(awk '/\[/{prefix=$0; next} $1{print prefix $0}' $RAUC_SYSTEM_CONF)
+
+ROOTFS_DEV=$(mount | grep "on / type ext4" | cut -d " " -f 1)
+
+ROOTFS_SLOT=$(echo "$PARSED_CONF" | grep "$ROOTFS_DEV" | grep -Eo "rootfs\.[0-9]")
+APPFS_SLOT=$(echo "$PARSED_CONF" | grep "$1" | grep -E "\[slot.[a-z]+.[01]\]" | grep -Eo "[a-z]+\.[01]")
+
+PARENT_ROOTFS_SLOT=$(echo "$PARSED_CONF" | grep "\[slot\.$APPFS_SLOT\]parent=" | grep -o "rootfs\.[01]")
+
+if [ "$ROOTFS_SLOT" = "$PARENT_ROOTFS_SLOT" ]; then
+	echo 1
+else
+	echo 0
+fi

--- a/recipes-core/rauc/rauc/mx8mm/system_emmc.conf
+++ b/recipes-core/rauc/rauc/mx8mm/system_emmc.conf
@@ -25,6 +25,11 @@ device=/dev/mmcblk2p1
 type=vfat
 parent=rootfs.0
 
+[slot.appfs.0]
+device=/dev/mmcblk2p7
+type=ext4
+parent=rootfs.0
+
 # System B
 [slot.rootfs.1]
 device=/dev/mmcblk2p6
@@ -34,4 +39,9 @@ bootname=system1
 [slot.boot.1]
 device=/dev/mmcblk2p2
 type=vfat
+parent=rootfs.1
+
+[slot.appfs.1]
+device=/dev/mmcblk2p8
+type=ext4
 parent=rootfs.1

--- a/recipes-core/rauc/rauc_%.bbappend
+++ b/recipes-core/rauc/rauc_%.bbappend
@@ -2,4 +2,22 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'emmc', 'file://system_emmc.conf', 'file://system_nand.conf', d)} \
+    file://is-parent-active \
+    file://appfs.rules \
+"
+
+do_install_prepend() {
+	sed -i -e 's!@LIBDIR@!${libdir}!g' -e 's!@PN@!${PN}!g' ${WORKDIR}/appfs.rules
+}
+
+do_install_append() {
+    install -d ${D}${libdir}/${PN}/
+    install -d ${D}${sysconfdir}/udev/rules.d/
+    install -m 755 ${WORKDIR}/is-parent-active ${D}${libdir}/${PN}/
+    install -m 644 ${WORKDIR}/appfs.rules ${D}${sysconfdir}/udev/rules.d/
+}
+
+FILES_${PN} += " \
+    ${libdir}/${PN}/is-parent-active \
+    ${sysconfdir}/udev/rules.d/appfs.rules \
 "


### PR DESCRIPTION
Add partitions and slots that may contain user-specific applications. The correct partition to be mounted is determined by the corresponding parent root filesystem in use. A udev rule is being added that automatically creates a symlink of the application filesystem device. The partition is also mounted automatically to `/mnt/app`.