### PR TITLE
phytec-esec-test-image: Add mmc-utils

### DIFF
--- a/recipes-images/images/phytec-esec-test-image.bb
+++ b/recipes-images/images/phytec-esec-test-image.bb
@@ -27,6 +27,7 @@ IMAGE_INSTALL = " \
     curl \
     iproute2 \
     awsclient \
+    mmc-utils \
 "
 
 IMAGE_INSTALL_append_mx6 = " firmwared"


### PR DESCRIPTION
mmc-utils is needed for writing the extended CSD register of the eMMC when updating the bootloader.