### PR TITLE
Clean the tpm packagegroups for openssl and pkcs#11 and Add Phytec-Esec Startimage

### DIFF
--- a/recipes-images/bundles/phytec-esec-start-bundle.bb
+++ b/recipes-images/bundles/phytec-esec-start-bundle.bb
@@ -1,0 +1,3 @@
+require recipes-images/bundles/phytec-base-bundle.inc
+
+RAUC_SLOT_rootfs = "phytec-esec-start-image"

--- a/recipes-images/images/phytec-esec-start-image.bb
+++ b/recipes-images/images/phytec-esec-start-image.bb
@@ -1,0 +1,32 @@
+SUMMARY = "Phytec's headless image"
+DESCRIPTION = "no graphics support in this image"
+LICENSE = "MIT"
+inherit core-image
+
+include security/userauthentication.inc
+include security/simple-fitimage.inc
+
+IMAGE_ROOTFS_SIZE ?= "8192"
+
+IMAGE_INSTALL = " \
+    packagegroup-machine-base \
+    packagegroup-core-boot \
+    packagegroup-update \
+    openssh \
+    ${@bb.utils.contains("MACHINE_FEATURES", "tpm2", "packagegroup-openssl-tpm2", "",  d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "tpm2", "packagegroup-pkcs11-tpm2", "", d)} \
+    chrony \
+    coreutils \
+    keyutils \
+    lvm2 \
+    util-linux \
+    tzdata \
+    curl \
+    iproute2 \
+    awsclient \
+    phytec-board-config \
+    phytec-board-info \
+"
+
+IMAGE_INSTALL_append_mx6 = " firmwared"
+IMAGE_INSTALL_append_mx6ul = " firmwared"

--- a/recipes-images/images/phytec-esec-test-image.bb
+++ b/recipes-images/images/phytec-esec-test-image.bb
@@ -16,6 +16,7 @@ IMAGE_INSTALL = " \
     ${@bb.utils.contains("MACHINE_FEATURES", "tpm2", "packagegroup-openssl-tpm2", "",  d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "tpm2", "packagegroup-pkcs11-tpm2", "", d)} \
     chrony \
+    ${@bb.utils.contains("MACHINE_FEATURES", "tpm2", "packagegroup-provision-tpm", "", d)} \
     coreutils \
     keyutils \
     lvm2 \

--- a/recipes-images/packagegroups/packagegroup-openssl-tpm2.bb
+++ b/recipes-images/packagegroups/packagegroup-openssl-tpm2.bb
@@ -6,7 +6,6 @@ inherit packagegroup
 SUMMARY_packagegroup-openssl-tpm2 = "openssl with TPM 2.0 support"
 
 RDEPENDS_${PN} = " \
-    tpm2-tools \
     tpm2-tss \
     libtss2 \
     libtss2-mu \

--- a/recipes-images/packagegroups/packagegroup-pkcs11-tpm2.bb
+++ b/recipes-images/packagegroups/packagegroup-pkcs11-tpm2.bb
@@ -6,15 +6,7 @@ inherit packagegroup
 SUMMARY_packagegroup-pkcs11-tpm2 = "PKCS11 with TPM 2.0 support"
 
 RDEPENDS_${PN} = " \
-    tpm2-tools \
-    tpm2-tss \
-    libtss2 \
-    libtss2-mu \
-    libtss2-tcti-device \
-    libtss2-tcti-mssim \
     opensc \
     libp11 \
-    gnutls \
-    gnutls-bin \
     tpm2-pkcs11 \
 "

--- a/recipes-images/packagegroups/packagegroup-provision-tpm.bb
+++ b/recipes-images/packagegroups/packagegroup-provision-tpm.bb
@@ -1,9 +1,7 @@
-DESCRIPTION = "Packagegroup for PKCS11 with TPM2."
+DESCRIPTION = "Packagegroup for TPM2 provisioning"
 LICENSE = "MIT"
 
 inherit packagegroup
-
-SUMMARY_packagegroup-pkcs11-tpm2 = "PKCS11 with TPM 2.0 support"
 
 RDEPENDS_${PN} = " \
     tpm2-tools \

--- a/recipes-images/packagegroups/packagegroup-provision-tpm.bb
+++ b/recipes-images/packagegroups/packagegroup-provision-tpm.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Packagegroup for PKCS11 with TPM2."
+LICENSE = "MIT"
+
+inherit packagegroup
+
+SUMMARY_packagegroup-pkcs11-tpm2 = "PKCS11 with TPM 2.0 support"
+
+RDEPENDS_${PN} = " \
+    tpm2-tools \
+"


### PR DESCRIPTION
1. Remove not necessary tools from the packageroup openssl and pkcs#11
2. Create new tpm provissioning packagegroup with tpm2-tools
3. Create start image for delivery PHYTEC Boards with ESEC IoT Device Manager Platform Support
4. Create rauc Bundle for the start image