### PR TITLE
set awsclient start condition

### DIFF
--- a/recipes-connectivity/awsclient/awsclient/awsclient.service
+++ b/recipes-connectivity/awsclient/awsclient/awsclient.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=oneshot
 User=root
-ExecStart=/usr/bin/awsclient
+ExecStart=/bin/sh -c '[ $(/usr/bin/jq .awsclient < /mnt/config/aws/config/esec.config | grep start | wc -l) -eq 1 ] && /usr/bin/awsclient || { echo "Contract has not been accepted yet"; exit 2; }'
 WorkingDirectory=/mnt/config/aws/
 TimeoutStartSec=15m
 

--- a/recipes-support/provisioning/files/phytec-board-config.sh
+++ b/recipes-support/provisioning/files/phytec-board-config.sh
@@ -201,6 +201,7 @@ set_onboarded() {
     jsontxt=$(echo ${jsontxt} | jq --arg para timestamp --arg val "$vdate" '.onboarding[$para] =   $val')
     echo ${jsontxt} | jq . > ${FILE}
     set_awsclient start
+    systemctl restart awsclient
 }
 
 set_awsclient(){


### PR DESCRIPTION
The awsclient should be start after the acception of the contract and the successful onboarding of the device