### PR TITLE
rauc-hawkbit-updater: Add recipe to create link to config file

### DIFF
--- a/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_%.bbappend
+++ b/recipes-support/rauc-hawkbit-updater/rauc-hawkbit-updater_%.bbappend
@@ -1,0 +1,4 @@
+do_install_append () {
+    rm ${D}${sysconfdir}/${PN}/config.conf
+    ln -s /mnt/config/hawkbit/config.cfg ${D}${sysconfdir}/rauc-hawkbit-updater/config.conf
+}


### PR DESCRIPTION
Create symbolic link pointing to "mnt/config/rauc-hawkbit-updater/
config.cfg" since rauc-hawkbit-updater expects the config file in
"/etc/rauc-hawkbit-updater/config.conf".

Signed-off-by: Cem Tenruh <c.tenruh@phytec.de>