### PR TITLE
phytec-board-info: Set source directory to working directory

### DIFF
--- a/recipes-support/phytec-board-info/phytec-board-info.bb
+++ b/recipes-support/phytec-board-info/phytec-board-info.bb
@@ -8,6 +8,8 @@ SRC_URI = " \
     file://phytec-board-info.sh \
 "
 
+S = "${WORKDIR}"
+
 do_install() {
     install -d ${D}${bindir}
     install -m 755 ${S}/phytec-board-info.sh ${D}${bindir}/${BPN}


### PR DESCRIPTION
Somehow #18 was merged with an old version where this is not fixed.