### PR TITLE
blink-led: Add blink skript to signal RAUC slot usage

### DIFF
--- a/recipes-support/blink-led/blink-led.bb
+++ b/recipes-support/blink-led/blink-led.bb
@@ -1,6 +1,8 @@
 SUMMARY = "LED blink test"
 LICENSE = "MIT"
 
+inherit systemd
+
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = " \
@@ -8,20 +10,18 @@ SRC_URI = " \
     file://blink-led \
 "
 
-SYSTEMD_SERVICE_${PN} = "blink.service"
-
-BLINK_COLOR = "led-red"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
+SYSTEMD_SERVICE_${PN} = "blink-led.service"
 
 do_install() {
     install -d ${D}/${bindir}
-    sed -i -e "s/@COLOR@/${BLINK_COLOR}/g" ${WORKDIR}/blink-led
     install -m 0755 ${WORKDIR}/blink-led ${D}/usr/bin/
 
-    install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/blink-led.service ${D}${systemd_unitdir}/system/
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/blink-led.service ${D}${systemd_system_unitdir}
 }
 
 FILES_${PN} = " \
     ${bindir}/blink-led \
-    ${systemd_unitdir}/system/blink-led.service \
+    ${systemd_system_unitdir}/blink-led.service \
 "

--- a/recipes-support/blink-led/blink-led/blink-led
+++ b/recipes-support/blink-led/blink-led/blink-led
@@ -1,10 +1,22 @@
 #!/bin/sh
 
-if [ "@COLOR@" = "led-red" ]; then
+if (rauc status | grep -q 'Booted from: rootfs.0 (system0)' &&
+   rauc status | grep -q 'Activated: rootfs.1 (system1)') ||
+   (rauc status | grep -q 'Booted from: rootfs.1 (system1)' &&
+   rauc status | grep -q 'Activated: rootfs.0 (system0)'); then
+    echo 0 > /sys/class/leds/led-green/brightness
+    echo 0 > /sys/class/leds/led-blue/brightness
+    echo heartbeat > /sys/class/leds/led-red/trigger
 
-        echo 0 > /sys/class/leds/led-blue/brightness
-else
-        echo 0 > /sys/class/leds/led-red/brightness
+elif rauc status | grep -q 'Booted from: rootfs.1 (system1)' &&
+     rauc status | grep -q 'Activated: rootfs.1 (system1)'; then
+    echo 0 > /sys/class/leds/led-green/brightness
+    echo 0 > /sys/class/leds/led-red/brightness
+    echo heartbeat > /sys/class/leds/led-blue/trigger
+
+elif rauc status | grep -q 'Booted from: rootfs.0 (system0)' &&
+     rauc status | grep -q 'Activated: rootfs.0 (system0)'; then
+    echo 0 > /sys/class/leds/led-blue/brightness
+    echo 0 > /sys/class/leds/led-red/brightness
+    echo heartbeat > /sys/class/leds/led-green/trigger
 fi
-echo 0 > /sys/class/leds/led-green/brightness
-echo heartbeat > /sys/class/leds/@COLOR@/trigger

--- a/recipes-support/blink-led/blink-led/blink-led.service
+++ b/recipes-support/blink-led/blink-led/blink-led.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=LED-blink test
-After=syslog.target
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/blink-led
+Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add blink-led script and service to show the current rauc slot and the need to switch slots after an update.
Signed-off-by: Cem Tenruh <c.tenruh@phytec.de>