### PR TITLE
recipes-support: provisioning: provision-tpm.sh: Check length for Cert Common Name

### DIFF
--- a/recipes-support/provisioning/files/provision-tpm.sh
+++ b/recipes-support/provisioning/files/provision-tpm.sh
@@ -93,8 +93,13 @@ setup_devuid() {
 
 # Create Device Common Name
 setup_devcn() {
-    val=$(cat /proc/device-tree/model | cut -d ' ' -f 2)
-    export DEV_CN="${val}-${DEV_UID}"
+    val=$(cat /proc/device-tree/model | cut -d ' ' -f 2 | cut -d '-' -f 1)
+    soc=$(cat /sys/devices/soc0/soc_id | tr -d '.')
+    export DEV_CN="${val}-${soc}-${DEV_UID}"
+    if [ ${#DEV_CN} -gt 32 ]; then
+        DEV_CN="phy-${soc}-${DEV_UID}"
+    fi
+    export DEV_CN
 }
 
 # Init Root Certificate


### PR DESCRIPTION
Common name in the certificate have a limitation in length of 32
characters.
old:   phyBOARD-Polis-imx8mm-123456789012
new: phyBOARD-imx8mm-123456789012
if length > 32 then
phy-imx8mm-123456789012