### PR TITLE
blink-led: Add blink skript to signal RAUC slot usage

### DIFF
--- a/recipes-support/blink-led/blink-led/blink-led
+++ b/recipes-support/blink-led/blink-led/blink-led
@@ -20,3 +20,12 @@ elif rauc status | grep -q 'Booted from: rootfs.0 (system0)' &&
     echo 0 > /sys/class/leds/led-red/brightness
     echo heartbeat > /sys/class/leds/led-green/trigger
 fi
+rauc_status_old=$(rauc status)
+
+while true; do
+    if [ "$rauc_status_old" != "$(rauc status)" ]
+    then
+        systemctl restart blink-led
+    fi
+    sleep 3
+done

--- a/recipes-support/blink-led/blink-led/blink-led.service
+++ b/recipes-support/blink-led/blink-led/blink-led.service
@@ -4,8 +4,6 @@ Description=LED-blink test
 [Service]
 Type=simple
 ExecStart=/usr/bin/blink-led
-Restart=always
-RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
with this commit the blink-led.service will restart only
when the rauc status changes.
booted and activated system0: LED green
booted and activated system1: LED blue
reboot needed after update or slot change: LED red

Signed-off-by: Cem Tenruh <c.tenruh@phytec.de>