### PR TITLE
u-boot-imx: Update patch to enable RAUC as default boot option

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/0002-include-configs-Enable-booting-A-B-system-by-default.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0002-include-configs-Enable-booting-A-B-system-by-default.patch
@@ -1,6 +1,6 @@
 From 62988c54b7773eb0705805c00427510ce011152f Mon Sep 17 00:00:00 2001
 From: Martin Schwan <m.schwan@phytec.de>
-Date: Mon, 15 Feb 2021 15:22:16 +0100
+Date: Tue, 8 Jun 2021 15:54:03 +0200
 Subject: [PATCH 2/2] include: configs: Enable booting A/B system by default
  for i.MX8M Mini
 
@@ -10,18 +10,18 @@ Signed-off-by: Martin Schwan <m.schwan@phytec.de>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/configs/phycore_imx8mm.h b/include/configs/phycore_imx8mm.h
-index 02793fc554..469df45e15 100644
+index bdad510b8b..1246d32865 100644
 --- a/include/configs/phycore_imx8mm.h
 +++ b/include/configs/phycore_imx8mm.h
-@@ -77,7 +77,7 @@
- 		"else " \
- 			"echo WARN: Cannot load the DT; " \
- 		"fi;\0" \
--	"doraucboot=0\0" \
-+	"doraucboot=1\0" \
- 	"raucdev=2\0" \
- 	PHYCORE_RAUC_ENV_BOOTLOGIC
+@@ -90,7 +90,7 @@
  
+ #define CONFIG_BOOTCOMMAND \
+ 	"mmc dev ${mmcdev}; if mmc rescan; then " \
+-		"test -n \"${doraucboot}\" || setenv doraucboot 0; " \
++		"test -n \"${doraucboot}\" || setenv doraucboot 1; " \
+ 		"if test ${doraucboot} = 1; then " \
+ 			"run raucboot; " \
+ 		"elif run loadimage; then " \
 -- 
-2.30.1
+2.31.1
 


### PR DESCRIPTION
For the newest zeus branch of meta-yogurt, the patch enabling RAUC boot by default needs updating.