### PR TITLE
phytec-board-config: Add brace to avoid syntax error

### DIFF
--- a/recipes-support/provisioning/files/phytec-board-config.sh
+++ b/recipes-support/provisioning/files/phytec-board-config.sh
@@ -373,6 +373,7 @@ do_restart_awsclient() {
     systemctl restart awsclient
     systemctl restart awsclient
     systemctl restart awsclient
+}
 
 do_login() {
     login_state=$(awk '/common-auth/ { if (substr($1,1,1) ~ /^[# ]/ ) print 1; else print 0}' /etc/pam.d/${2})


### PR DESCRIPTION
a brace was missing in the do_restart_awsclient function.

Signed-off-by: Cem Tenruh <c.tenruh@phytec.de>