### PR TITLE
phytec-board-config: Adjust login method text

### DIFF
--- a/recipes-support/provisioning/files/phytec-board-config.sh
+++ b/recipes-support/provisioning/files/phytec-board-config.sh
@@ -383,7 +383,7 @@ do_login() {
         password_state="OFF"
         google_state="ON"
     fi
-    login_newstate=$(whiptail --radiolist "Choose the ROOT Verification for" 20 60 10 \
+    login_newstate=$(whiptail --radiolist "Choose the login method for $1. (Select an item with the arrow keys and spacebar)" $WT_HEIGHT $WT_WIDTH 2 \
         "0" "Static Password" $password_state \
         "1" "One-time Password (IoT Device Suite platform)" $google_state \
         3>&1 1>&2 2>&3)


### PR DESCRIPTION
Change the login method dialog text to be more descriptive. Add a note for the user to use the arrow keys and spacebar to select items. Also change the width and height of the dialog using the generic variables.

