### PR TITLE
recipes-connectivity: awsclient: Set restart timer to 5m for a better user experience

### DIFF
--- a/recipes-connectivity/awsclient/awsclient/awsclient.service
+++ b/recipes-connectivity/awsclient/awsclient/awsclient.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=OSB AWS Client
+Description=connagtive AWS Client
 After=network.target
 
 [Service]

--- a/recipes-connectivity/awsclient/awsclient/awsclient.timer
+++ b/recipes-connectivity/awsclient/awsclient/awsclient.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Timer for executing OSB AWS Client periodically
+Description=Timer for executing connagtive AWS Client periodically
 
 [Timer]
 OnActiveSec=1m
-OnUnitActiveSec=30m
+OnUnitActiveSec=5m
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
note from Roland Marx 