### PR TITLE
Fix and improve blink-led service

### DIFF
--- a/recipes-support/blink-led/blink-led.bb
+++ b/recipes-support/blink-led/blink-led.bb
@@ -7,10 +7,11 @@ inherit systemd
 
 SRC_URI = " \
     file://blink-led.service \
+    file://blink-led.timer \
     file://blink-led \
 "
 
-SYSTEMD_SERVICE_${PN} = "blink-led.service"
+SYSTEMD_SERVICE_${PN} = "blink-led.timer"
 
 do_install() {
     install -d ${D}${bindir}
@@ -18,9 +19,11 @@ do_install() {
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/blink-led.service ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/blink-led.timer ${D}${systemd_system_unitdir}
 }
 
 FILES_${PN} = " \
     ${bindir}/blink-led \
     ${systemd_system_unitdir}/blink-led.service \
+    ${systemd_system_unitdir}/blink-led.timer \
 "

--- a/recipes-support/blink-led/blink-led.bb
+++ b/recipes-support/blink-led/blink-led.bb
@@ -1,21 +1,20 @@
-SUMMARY = "LED blink test"
+SUMMARY = "Blink system LED depending on RAUC status"
+
 LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 inherit systemd
-
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = " \
     file://blink-led.service \
     file://blink-led \
 "
 
-SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 SYSTEMD_SERVICE_${PN} = "blink-led.service"
 
 do_install() {
-    install -d ${D}/${bindir}
-    install -m 0755 ${WORKDIR}/blink-led ${D}/usr/bin/
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/blink-led ${D}${bindir}
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/blink-led.service ${D}${systemd_system_unitdir}

--- a/recipes-support/blink-led/blink-led/blink-led
+++ b/recipes-support/blink-led/blink-led/blink-led
@@ -1,31 +1,19 @@
 #!/bin/sh
 
-if (rauc status | grep -q 'Booted from: rootfs.0 (system0)' &&
-   rauc status | grep -q 'Activated: rootfs.1 (system1)') ||
-   (rauc status | grep -q 'Booted from: rootfs.1 (system1)' &&
-   rauc status | grep -q 'Activated: rootfs.0 (system0)'); then
-    echo 0 > /sys/class/leds/led-green/brightness
-    echo 0 > /sys/class/leds/led-blue/brightness
-    echo heartbeat > /sys/class/leds/led-red/trigger
+RAUC_STATUS=$(rauc status)
+BOOTED_SLOT=$(printf "$RAUC_STATUS" | grep -Eo "(Booted from: [[:alpha:]]+.)[01]" | grep -Eo "[01]$")
+ACTIVATED_SLOT=$(printf "$RAUC_STATUS" | grep -Eo "(Activated: [[:alpha:]]+.)[01]" | grep -Eo "[01]$")
 
-elif rauc status | grep -q 'Booted from: rootfs.1 (system1)' &&
-     rauc status | grep -q 'Activated: rootfs.1 (system1)'; then
-    echo 0 > /sys/class/leds/led-green/brightness
-    echo 0 > /sys/class/leds/led-red/brightness
-    echo heartbeat > /sys/class/leds/led-blue/trigger
-
-elif rauc status | grep -q 'Booted from: rootfs.0 (system0)' &&
-     rauc status | grep -q 'Activated: rootfs.0 (system0)'; then
-    echo 0 > /sys/class/leds/led-blue/brightness
-    echo 0 > /sys/class/leds/led-red/brightness
-    echo heartbeat > /sys/class/leds/led-green/trigger
+if [ \( "$BOOTED_SLOT" = 0 -a "$ACTIVATED_SLOT" = 1 \) -o \( "$BOOTED_SLOT" = 1 -a "$ACTIVATED_SLOT" = 0 \) ]; then
+    printf 0 > /sys/class/leds/green\:cpu/brightness
+    printf 0 > /sys/class/leds/blue\:disk/brightness
+    printf heartbeat > /sys/class/leds/red\:disk/trigger
+elif [ "$BOOTED_SLOT" = 0 ]; then
+    printf 0 > /sys/class/leds/blue\:disk/brightness
+    printf 0 > /sys/class/leds/red\:disk/brightness
+    printf heartbeat > /sys/class/leds/green\:cpu/trigger
+elif [ "$BOOTED_SLOT" = 1 ]; then
+    printf 0 > /sys/class/leds/green\:cpu/brightness
+    printf 0 > /sys/class/leds/red\:disk/brightness
+    printf heartbeat > /sys/class/leds/blue\:disk/trigger
 fi
-rauc_status_old=$(rauc status)
-
-while true; do
-    if [ "$rauc_status_old" != "$(rauc status)" ]
-    then
-        systemctl restart blink-led
-    fi
-    sleep 3
-done

--- a/recipes-support/blink-led/blink-led/blink-led.service
+++ b/recipes-support/blink-led/blink-led/blink-led.service
@@ -1,9 +1,9 @@
 [Unit]
-Description=LED-blink test
+Description=Blink system LED depending on RAUC status
 After=rauc.service
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/bin/blink-led
 
 [Install]

--- a/recipes-support/blink-led/blink-led/blink-led.timer
+++ b/recipes-support/blink-led/blink-led/blink-led.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Periodically check RAUC status for blink-led service
+
+[Timer]
+OnActiveSec=3
+OnUnitActiveSec=3
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Use a systemd timer to periodically check for the RAUC status and update the LED color accordingly. Also correct the naming of the LED devices.

Remove redundant default setting of enabling systemd service. Fix some styling and minor syntax.