### PR TITLE
base-files: Link config and app partition to directory in root

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -18,6 +18,9 @@ do_install_append() {
     case "${DISTRO_FEATURES}" in
         *connagtive-provisioning*) ;;
         *)
-            install -m 0755 ${WORKDIR}/welcome-connagtive.sh ${D}${sysconfdir}/profile.d/welcome-connagtive.sh ;;
+            install -m 0755 ${WORKDIR}/welcome-connagtive.sh ${D}${sysconfdir}/profile.d/welcome-connagtive.sh
+            ln -s /mnt/config ${D}/config
+            ln -s /mnt/app ${D}/app
+            ;;
     esac
 }


### PR DESCRIPTION
Create symbolic links to /mnt/config and /mnt/app in the root directory.