### PR TITLE
rauc: Use more variables for parsing system.conf

### DIFF
--- a/recipes-core/rauc/rauc/mx8mm/system_emmc.conf
+++ b/recipes-core/rauc/rauc/mx8mm/system_emmc.conf
@@ -1,47 +1,48 @@
 [system]
 compatible=@MACHINE@
-bootloader=uboot
+bootloader=@BOOTLOADER@
 mountprefix=/mnt/rauc
 
 [handlers]
-pre-install=/usr/bin/rauc_downgrade_barrier.sh
+pre-install=/usr/lib/rauc/rauc-pre-install.sh
+post-install=/usr/lib/rauc/rauc-post-install.sh
 
 [keyring]
-path=ca.cert.pem
+path=@RAUC_KEYRING_FILE@
 
 # Bootloader
 [slot.bootloader.0]
-device=/dev/mmcblk2
+device=/dev/mmcblk@EMMC_DEV@
 type=boot-emmc
 
 # System A
 [slot.rootfs.0]
-device=/dev/mmcblk2p5
+device=@ROOTFS_0_DEV@
 type=ext4
 bootname=system0
 
 [slot.boot.0]
-device=/dev/mmcblk2p1
+device=/dev/mmcblk@EMMC_DEV@p1
 type=vfat
 parent=rootfs.0
 
 [slot.appfs.0]
-device=/dev/mmcblk2p7
+device=/dev/mmcblk@EMMC_DEV@p7
 type=ext4
 parent=rootfs.0
 
 # System B
 [slot.rootfs.1]
-device=/dev/mmcblk2p6
+device=@ROOTFS_1_DEV@
 type=ext4
 bootname=system1
 
 [slot.boot.1]
-device=/dev/mmcblk2p2
+device=/dev/mmcblk@EMMC_DEV@p2
 type=vfat
 parent=rootfs.1
 
 [slot.appfs.1]
-device=/dev/mmcblk2p8
+device=/dev/mmcblk@EMMC_DEV@p8
 type=ext4
 parent=rootfs.1


### PR DESCRIPTION
Use more variables for parsing RAUC's system.conf to be up to date with the version provided by meta-ampliphy.