### PR TITLE
provisioning: Fix SoC ID sysfs path

### DIFF
--- a/recipes-support/provisioning/files/phytec-board-config.sh
+++ b/recipes-support/provisioning/files/phytec-board-config.sh
@@ -37,7 +37,7 @@ REMOTEMANAGER_PATH="${CONFIG_PATH}/esec/"
 SSHPUBKEY_PATH="${CONFIG_PATH}/.ssh/"
 AUTHENT_FILE="${REMOTEMANAGER_PATH}.google_authenticator"
 
-TPM_PIN=$(cat /sys/devices/soc0/soc_uid | head -c 7)
+TPM_PIN=$(cat /sys/devices/soc0/serial_number | head -c 7)
 
 calc_wt_size() {
     # NOTE: it's tempting to redirect stderr to /dev/null, so supress error

--- a/recipes-support/provisioning/files/provision-tpm.sh
+++ b/recipes-support/provisioning/files/provision-tpm.sh
@@ -24,7 +24,7 @@ hsmpkcs11tool='pkcs11-tool --module /usr/lib/opensc-pkcs11.so'
 
 # Generate SO-PIN
 TPM_SOPIN=$(tpm2_getrandom --hex 8 | tr -dc 0-9)
-TPM_PIN=$(cat /sys/devices/soc0/soc_uid | head -c 7)
+TPM_PIN=$(cat /sys/devices/soc0/serial_number | head -c 7)
 
 USAGE="\
 Usage:  $(basename $0) --p12init P12CONTAINER ROOTCA


### PR DESCRIPTION
With a newer Kernel version in hardknott, the sysfs path for the SoC ID changed from "soc_uid" to "soc_id".