### PR TITLE
conf: distro: ampliphy-vendor-connagtive: Add overrides for protectionshield

### DIFF
--- a/conf/distro/ampliphy-vendor-connagtive.conf
+++ b/conf/distro/ampliphy-vendor-connagtive.conf
@@ -7,6 +7,7 @@ DISTRO_NAME = "ampliphy Vendor Connagtive (Phytec Vendor Distribution + Connagti
 #shieldlow - shieldmedium - shieldhigh
 DISTRO_FEATURES += "protectionshield"
 PROTECTION_SHIELD_LEVEL = "shieldmedium"
+OVERRIDES_append = ":protectionshield:${PROTECTION_SHIELD_LEVEL}"
 
 #password or authenticator for console and sshd
 CONNAGTIVE_ROOT_AUTHENTICATION = "password"


### PR DESCRIPTION
The Overides moved from conf/distro/common.inc to
conf/distro/common-secure.inc, which is not included in this layer.

Signed-off-by: Maik Otto <m.otto@phytec.de>