### PR TITLE
phytec-board-config: Add remotemanager service status

### DIFF
--- a/recipes-support/provisioning/files/phytec-board-config.sh
+++ b/recipes-support/provisioning/files/phytec-board-config.sh
@@ -195,6 +195,7 @@ do_awsconfig() {
         ["devtype", "phytec-board-info --machine | tr -d \"\\n\""],
         ["serial", "phytec-board-info --serial | tr -d \"\\n\""],
         ["remote_manager_version", "remotemanager -v | tr -d \"\\n\""],
+        ["remotemanager_service_status", "systemctl is-active remotemanager.service | tr -d \"\\n\""],
         ["rauc-hawkbit-updater", "rauc-hawkbit-updater -v | tr -d \"\\n\""]
     ]
 }


### PR DESCRIPTION
Add the remotemanager's service status to the shadow commands of the awsclient.