### PR TITLE
recipes-tpm2: Remove all appends

### DIFF
--- a/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_%.bbappend
+++ b/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_%.bbappend
@@ -1,1 +1,0 @@
-EXTRA_OECONF += "--with-storedir=/mnt/config/tpm2/pkcs11"


### PR DESCRIPTION
Remove additional package config settings for tpm2, as they are already applied by meta-ampliphy now.

Signed-off-by: Maik Otto <m.otto@phytec.de>