### PR TITLE
Migration distro and image from zeus to hardknott

### DIFF
--- a/conf/distro/ampliphy-vendor-connagtive.conf
+++ b/conf/distro/ampliphy-vendor-connagtive.conf
@@ -1,13 +1,5 @@
 require conf/distro/ampliphy-vendor-rauc.conf
+require conf/distro/common-secure-connagtive.inc
 
 DISTRO = "ampliphy-vendor-connagtive"
 DISTRO_NAME = "ampliphy Vendor Connagtive (Phytec Vendor Distribution + Connagtive IoT Device Suite)"
-
-#add protection shield level
-#shieldlow - shieldmedium - shieldhigh
-DISTRO_FEATURES += "protectionshield"
-PROTECTION_SHIELD_LEVEL = "shieldmedium"
-OVERRIDES_append = ":protectionshield:${PROTECTION_SHIELD_LEVEL}"
-
-#password or authenticator for console and sshd
-CONNAGTIVE_ROOT_AUTHENTICATION = "password"

--- a/conf/distro/common-secure-connagtive.inc
+++ b/conf/distro/common-secure-connagtive.inc
@@ -1,0 +1,8 @@
+#add protection shield level
+#shieldlow - shieldmedium - shieldhigh
+DISTRO_FEATURES += "protectionshield"
+PROTECTION_SHIELD_LEVEL = "shieldmedium"
+OVERRIDES_append = ":protectionshield:${PROTECTION_SHIELD_LEVEL}"
+
+#password or authenticator for console and sshd
+CONNAGTIVE_ROOT_AUTHENTICATION = "password"

--- a/conf/distro/common-secure-connagtive.inc
+++ b/conf/distro/common-secure-connagtive.inc
@@ -6,3 +6,6 @@ OVERRIDES_append = ":protectionshield:${PROTECTION_SHIELD_LEVEL}"
 
 #password or authenticator for console and sshd
 CONNAGTIVE_ROOT_AUTHENTICATION = "password"
+
+# Set phytec-dev-ca version 1.2 as default
+PREFERRED_VERSION_phytec-dev-ca = "1.2"

--- a/hardknott.xml
+++ b/hardknott.xml
@@ -10,6 +10,7 @@
       phyboard-polis-imx8mm-4/phytec-connagtive-test-image/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/phytec-connagtive-test-bundle/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/phytec-connagtive-start-image/ampliphy-vendor-connagtive,
+      phyboard-polis-imx8mm-4/phytec-connagtive-test-migration-zeus-to-hardknott-bundle/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/-c populate_sdk phytec-connagtive-start-image/ampliphy-vendor-connagtive,
       phygate-tauri-l-imx8mm-2/phytec-connagtive-provisioning-image/ampliphy-vendor-connagtive-provisioning,
       phygate-tauri-l-imx8mm-2/phytec-connagtive-test-image/ampliphy-vendor-connagtive,

--- a/recipes-images/bundles/phytec-connagtive-test-migration-zeus-to-hardknott-bundle.bb
+++ b/recipes-images/bundles/phytec-connagtive-test-migration-zeus-to-hardknott-bundle.bb
@@ -1,0 +1,8 @@
+require recipes-images/bundles/phytec-base-bundle.inc
+
+RAUC_SLOT_rootfs = "phytec-connagtive-test-migration-zeus-to-hardknott-image"
+
+# RAUC Bundle Format from zeus
+RAUC_BUNDLE_FORMAT = "plain"
+RAUC_KEY_FILE ?= "${CERT_PATH}/rauc/private/development-1.key.pem"
+RAUC_CERT_FILE ?= "${CERT_PATH}/rauc/development-1.cert.pem"

--- a/recipes-images/images/phytec-connagtive-test-migration-zeus-to-hardknott-image.bb
+++ b/recipes-images/images/phytec-connagtive-test-migration-zeus-to-hardknott-image.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Phytec's Connagtive IoT Device Suite Test Image Migration"
+DESCRIPTION = "Migration Image from zeus to hardknott"
+LICENSE = "MIT"
+
+require recipes-images/images/phytec-connagtive-test-image.bb
+
+IMAGE_INSTALL += " \
+    migration-zeus-to-hardknott \
+"

--- a/recipes-physecurity/phytec-dev-ca/phytec-dev-ca_1.2.bb
+++ b/recipes-physecurity/phytec-dev-ca/phytec-dev-ca_1.2.bb
@@ -1,0 +1,4 @@
+require recipes-physecurity/phytec-dev-ca/phytec-dev-ca.inc
+
+SRC_URI[tarball.md5sum] = "681c5685b4c248c7d9b8e01de8cb2d4d"
+SRC_URI[tarball.sha256sum] = "11accb040c48b2529d953add6fd505938f8bd09852dc7e77d0ecfd641a258bd0"

--- a/recipes-support/migration/files/migration-zeus-to-hardknott.sh
+++ b/recipes-support/migration/files/migration-zeus-to-hardknott.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+awsconfig="/mnt/config/aws/config/config.json"
+awsconfig_zeus="/mnt/config/aws/config/config-zeus.json"
+
+shadowcommands='[
+        ["timer", "grep OnUnitActiveSec= /lib/systemd/system/awsclient.timer | grep -o [^=]*.$ | tr -d \"\\n\""],
+        ["fs_cnf", "df | grep /mnt/config$ | tr -s \" \" | tr -d \"\\n\""],
+        ["fs_app", "df | grep /mnt/app$ | tr -s \" \" | tr -d \"\\n\""],
+        ["fs_root", "df | grep /$ | tr -s \" \" | tr -d \"\\n\""],
+        ["up", "cat /proc/uptime | tr -d \"\\n\""],
+        ["krn", "cat /proc/version | tr -d \"\\n\""],
+        ["cpu", "cat /proc/loadavg | tr -d \"\\n\""],
+        ["mem_a", "grep MemAvailable /proc/meminfo | tr -s \" \" | cut -d \" \" -f2 | tr -d \"\\n\""],
+        ["mem_f", "grep MemFree /proc/meminfo | tr -s \" \" | cut -d \" \" -f2 | tr -d \"\\n\""],
+        ["mem_t", "grep MemTotal /proc/meminfo | tr -s \" \" | cut -d \" \" -f2 | tr -d \"\\n\""],
+        ["simno", "phytec-board-info --simno | tr -d \"\\n\""],
+        ["compatible", "phytec-board-info --compatible | tr -d \"\\n\""],
+        ["hwver", "phytec-board-info --machine-version | tr -d \"\\n\""],
+        ["devtype", "phytec-board-info --machine | tr -d \"\\n\""],
+        ["serial", "phytec-board-info --serial | tr -d \"\\n\""],
+        ["remote_manager_version", "remotemanager -v | tr -d \"\\n\""],
+        ["remotemanager_service_status", "systemctl is-active remotemanager.service | tr -d \"\\n\""],
+        ["rauc-hawkbit-updater", "rauc-hawkbit-updater -v | tr -d \"\\n\""]
+    ]'
+
+if [ -f ${awsconfig} ]; then
+        if ! [ -f ${awsconfig_zeus} ]; then
+                cp ${awsconfig} ${awsconfig_zeus}
+        fi
+        jsontxt=$(cat ${awsconfig})
+        [[ $(echo ${jsontxt} | jq 'isempty(.shadow_commands[])') = true ]] && jsontxt=$(echo ${jsontxt} | jq --argjson val "${shadowcommands}" '.shadow_commands += $val')
+        echo ${jsontxt} | jq . > ${awsconfig}
+fi
+
+exit 0

--- a/recipes-support/migration/files/migration.service
+++ b/recipes-support/migration/files/migration.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Migration zeus to hardknott
+After=systemd-user-sessions.service
+After=rc-local.service
+Before=getty.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/migration-zeus-to-hardknott
+User=root
+WorkingDirectory=/mnt/config
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-support/migration/migration-zeus-to-hardknott_0.1.bb
+++ b/recipes-support/migration/migration-zeus-to-hardknott_0.1.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Migration Tool for conversion from zeus to hardknott"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "\
+    file://migration.service \
+    file://migration-zeus-to-hardknott.sh \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE_${PN} = "migration.service"
+
+do_install () {
+    install -d ${D}${bindir}/
+    install -m 0755 ${WORKDIR}/migration-zeus-to-hardknott.sh ${D}${bindir}/migration-zeus-to-hardknott
+
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/migration.service ${D}${systemd_unitdir}/system/
+}
+
+FILES_${PN} += " \
+    ${systemd_unitdir}/system/migration.service \
+"
+
+RDEPENDS_${PN} = " \
+    jq \
+"


### PR DESCRIPTION
an update from zeu to hardknott is not possible directly, because the following has changed
1. RAUC Bundle signing type has changed from plain (zeus) to the new type variety (hardknott)
2. RAUC certificate structure from selfsigned rauc ca to phytec main ca with rauc intermediate
3. The shadow_command has changed from hardcoded in awsclient version 1.3 (zeus) to configurable in aws/config.json by the awsclient 1.5 (hardknott)