### PR TITLE
hardknott manifest update

### DIFF
--- a/hardknott.xml
+++ b/hardknott.xml
@@ -10,7 +10,7 @@
       phyboard-polis-imx8mm-4/phytec-connagtive-test-bundle/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/phytec-connagtive-start-image/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/phytec-connagtive-test-migration-zeus-to-hardknott-bundle/ampliphy-vendor-connagtive,
-      phyboard-polis-imx8mm-4/-c populate_sdk phytec-connagtive-start-image/ampliphy-vendor-connagtive,
+      phyboard-polis-imx8mm-4/-c populate_sdk phytec-connagtive-test-image/ampliphy-vendor-connagtive,
       phygate-tauri-l-imx8mm-2/phytec-provisioning-image/ampliphy-vendor-provisioning,
       phygate-tauri-l-imx8mm-2/phytec-connagtive-test-bundle/ampliphy-vendor-connagtive,
       phygate-tauri-l-imx8mm-2/phytec-connagtive-start-image/ampliphy-vendor-connagtive

--- a/hardknott.xml
+++ b/hardknott.xml
@@ -7,13 +7,11 @@
     soc="iMX8MM"
     supported_builds="
       phyboard-polis-imx8mm-4/phytec-provisioning-image/ampliphy-vendor-provisioning,
-      phyboard-polis-imx8mm-4/phytec-connagtive-test-image/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/phytec-connagtive-test-bundle/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/phytec-connagtive-start-image/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/phytec-connagtive-test-migration-zeus-to-hardknott-bundle/ampliphy-vendor-connagtive,
       phyboard-polis-imx8mm-4/-c populate_sdk phytec-connagtive-start-image/ampliphy-vendor-connagtive,
       phygate-tauri-l-imx8mm-2/phytec-provisioning-image/ampliphy-vendor-provisioning,
-      phygate-tauri-l-imx8mm-2/phytec-connagtive-test-image/ampliphy-vendor-connagtive,
       phygate-tauri-l-imx8mm-2/phytec-connagtive-test-bundle/ampliphy-vendor-connagtive,
       phygate-tauri-l-imx8mm-2/phytec-connagtive-start-image/ampliphy-vendor-connagtive
     "/>

--- a/hardknott.xml
+++ b/hardknott.xml
@@ -2,9 +2,10 @@
 <manifest>
   <phytec
     pdn="hardknott"
-    release_uid="BSP-Yocto-FSL-i.MX8MM-hardknott"
-    bspextension="FSL"
+    release_uid="BSP-Yocto-Connagtive-i.MX8MM-hardknott"
+    bspextension="Connagtive"
     soc="iMX8MM"
+    build_container="yocto:ubuntu20.04"
     supported_builds="
       phyboard-polis-imx8mm-4/phytec-provisioning-image/ampliphy-vendor-provisioning,
       phyboard-polis-imx8mm-4/phytec-connagtive-test-bundle/ampliphy-vendor-connagtive,


### PR DESCRIPTION
- remove test image, because test bundle are in the foreground for the IoT device suite
- set test-image for SDK
- change from FSL to Connagtive in uid and extension